### PR TITLE
Update data.lua

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -123,7 +123,6 @@ for elevation_id, elevation_name in pairs({"lo", "hi"}) do
   local icon = "__fake-new-rails__/graphics/entity/stone-diagonal-1.png"
   data:extend(get_recipe_and_item_prototypes(name, icon))
   local entity = get_entity_prototype(name, icon, {2,2})
-  entity.build_grid_size = 1
   -- local offset = 11/32
   entity.picture = {
     north = { layers = get_sprite_layers( {


### PR DESCRIPTION
Changed diagonal rails to have build_grid_size = 2

The new diagonal rails shouldn't align with the old diagonal rails, (see https://forums.factorio.com/viewtopic.php?p=598119#p598119) and this makes it so that they can always connect to the curved pieces, this was not the case previously.